### PR TITLE
Redesign "More projects" section with button-style link

### DIFF
--- a/bmc.html
+++ b/bmc.html
@@ -165,7 +165,7 @@ html { scroll-behavior: smooth; }
 
 <header class="nav" id="nav">
   <a href="index.html" class="nav-logo">phuong vu</a>
-  <button class="nav-menu-btn" id="navMenuBtn" aria-label="Toggle menu">
+  <button type="button" class="nav-menu-btn" id="navMenuBtn" aria-label="Toggle menu">
     <span></span>
     <span></span>
     <span></span>
@@ -318,12 +318,12 @@ html { scroll-behavior: smooth; }
   </div>
 </footer>
 
-<button id="backToTop" aria-label="Back to top">
+<button type="button" id="backToTop" aria-label="Back to top">
   <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" d="M5 10l7-7m0 0l7 7m-7-7v18"/></svg>
 </button>
 
 <div class="lightbox" id="lightbox">
-  <button class="lightbox-close" aria-label="Close" id="lightboxClose">
+  <button type="button" class="lightbox-close" aria-label="Close" id="lightboxClose">
     <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" d="M6 18L18 6M6 6l12 12"/></svg>
   </button>
   <img src="" alt="Expanded view" id="lightboxImg">

--- a/graphic-design.html
+++ b/graphic-design.html
@@ -182,7 +182,7 @@ html { scroll-behavior: smooth; }
 
 <header class="nav" id="nav">
   <a href="index.html" class="nav-logo">phuong vu</a>
-  <button class="nav-menu-btn" id="navMenuBtn" aria-label="Toggle menu">
+  <button type="button" class="nav-menu-btn" id="navMenuBtn" aria-label="Toggle menu">
     <span></span>
     <span></span>
     <span></span>
@@ -390,13 +390,13 @@ html { scroll-behavior: smooth; }
   </div>
 </footer>
 
-<button id="backToTop" aria-label="Back to top">
+<button type="button" id="backToTop" aria-label="Back to top">
   <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" d="M5 10l7-7m0 0l7 7m-7-7v18"/></svg>
 </button>
 
 <!-- Lightbox -->
 <div class="lightbox" id="lightbox">
-  <button class="lightbox-close" aria-label="Close" id="lightboxClose">
+  <button type="button" class="lightbox-close" aria-label="Close" id="lightboxClose">
     <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" d="M6 18L18 6M6 6l12 12"/></svg>
   </button>
   <img src="" alt="Expanded view" id="lightboxImg">

--- a/index.html
+++ b/index.html
@@ -238,64 +238,32 @@ html { scroll-behavior: smooth; }
 
 /* More works */
 .more-link-wrap {
-  padding: 48px 0 0;
+  padding: 72px 0 0;
   display: flex; justify-content: center;
 }
 .more-link {
-  display: inline-flex; align-items: center; gap: 10px;
-  font-size: 14px; font-weight: 300; color: var(--text-secondary);
+  display: inline-flex; align-items: center; gap: 12px;
+  padding: 16px 32px; border-radius: var(--radius-md);
+  background: var(--surface-base);
+  border: 1px solid var(--border-strong);
+  font-size: 16px; font-weight: 400; letter-spacing: 0.01em;
+  color: var(--text-primary);
   text-decoration: none;
   font-family: var(--font-primary);
   font-variation-settings: "wdth" 100;
-  transition: color 250ms ease-out;
-  border-bottom: 1px solid var(--border-default); padding-bottom: 2px;
+  box-shadow: var(--shadow-subtle);
+  transition: transform 200ms ease-out, box-shadow 250ms ease-out, background 250ms ease-out, border-color 250ms ease-out;
 }
-.more-link:hover { color: var(--text-primary); border-color: var(--text-primary); }
-.more-link:visited { color: var(--text-secondary); }
-.more-link svg { width: 13px; height: 13px; stroke-width: 1.5; transition: transform 250ms ease-out; }
-.more-link:hover svg { transform: translateX(3px); }
-
-/* Cards section */
-.section-cards {
-  padding: 96px 64px;
-  background: var(--surface-raised);
-  border-top: 1px solid var(--border-default);
-  border-bottom: 1px solid var(--border-default);
+.more-link:hover {
+  transform: translateY(-2px);
+  box-shadow: var(--shadow-hover);
+  background: var(--surface-hover);
+  color: var(--text-primary);
+  border-color: var(--text-primary);
 }
-.cards-grid { display: grid; grid-template-columns: repeat(3,1fr); gap: 20px; margin-top: 48px; }
-.card {
-  background: var(--surface-base); border: 1px solid var(--border-default);
-  border-radius: var(--radius-md); overflow: hidden;
-  text-decoration: none; color: inherit;
-  display: flex; flex-direction: column;
-  transition: background 250ms ease-out;
-}
-.card { transition: background 250ms ease-out, box-shadow 250ms ease-out, transform 250ms ease-out; }
-.card:hover { background: var(--surface-hover); box-shadow: var(--shadow-hover); transform: translateY(-2px); }
-.card:visited { color: inherit; }
-.card-img { aspect-ratio: 4/3; overflow: hidden; background: var(--surface-raised); }
-.card-img img { width: 100%; height: 100%; object-fit: cover; transition: transform 600ms cubic-bezier(0.25, 0.46, 0.45, 0.94); }
-.card:hover .card-img img { transform: scale(1.04); }
-.card-body { padding: 20px 22px 24px; flex: 1; }
-.card-cat {
-  font-size: 11px; letter-spacing: 0.08em; text-transform: uppercase;
-  color: var(--text-muted);
-  font-family: var(--font-primary); font-weight: 300;
-  font-variation-settings: "wdth" 100;
-  margin-bottom: 8px;
-}
-.card-title {
-  font-size: 17px; font-weight: 400; color: var(--text-primary);
-  line-height: 1.35; margin-bottom: 8px;
-  font-family: var(--font-primary);
-  font-variation-settings: "wdth" 100;
-}
-.card-desc {
-  font-size: 13px; font-weight: 300; line-height: 1.65;
-  color: var(--text-secondary);
-  font-family: var(--font-primary);
-  font-variation-settings: "wdth" 100;
-}
+.more-link:visited { color: var(--text-primary); }
+.more-link svg { width: 16px; height: 16px; stroke-width: 1.5; transition: transform 250ms ease-out; }
+.more-link:hover svg { transform: translateX(4px); }
 
 /* About */
 .section-about { padding: 96px 64px; }
@@ -452,12 +420,11 @@ html { scroll-behavior: smooth; }
   .hero { padding: 100px 28px 64px; }
   .hero-inner { grid-template-columns: 1fr; gap: 40px; }
   .fluid-shape { width: 280px; height: 280px; }
-  .section-work, .section-cards, .section-about, .section-caps { padding-left: 28px; padding-right: 28px; }
+  .section-work, .section-about, .section-caps { padding-left: 28px; padding-right: 28px; }
   .footer { padding: 28px; }
   .project-row { grid-template-columns: 1fr; gap: 28px; }
   .project-row.reverse .project-text { order: 1; }
   .project-row.reverse .project-image { order: 2; }
-  .cards-grid { grid-template-columns: 1fr; }
   .about-grid { grid-template-columns: 1fr; gap: 40px; }
   .caps-grid { grid-template-columns: 1fr; gap: 36px; }
 }
@@ -587,80 +554,6 @@ html { scroll-behavior: smooth; }
         More design work
         <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5"><path stroke-linecap="round" stroke-linejoin="round" d="M17 8l4 4m0 0l-4 4m4-4H3"/></svg>
       </a>
-    </div>
-  </section>
-
-  <!-- Additional projects (cards) -->
-  <section class="section-cards">
-    <div>
-      <p class="section-eyebrow">additional work</p>
-      <h2 class="section-title">More projects</h2>
-    </div>
-    <div class="cards-grid">
-      <article class="card reveal">
-        <a href="intervention.html" style="text-decoration:none; color:inherit; display:flex; flex-direction:column; height:100%;">
-          <div class="card-img">
-            <img src="images/other/intervention/img004.jpg" alt="Pawsitively Clean" loading="lazy">
-          </div>
-          <div class="card-body">
-            <p class="card-cat">public intervention</p>
-            <h3 class="card-title">Pawsitively clean</h3>
-            <p class="card-desc">Friendly sidewalk prompts encouraging dog owners to keep shared spaces clean.</p>
-          </div>
-        </a>
-      </article>
-
-      <article class="card reveal" style="transition-delay:80ms">
-        <a href="infographic.html" style="text-decoration:none; color:inherit; display:flex; flex-direction:column; height:100%;">
-          <div class="card-img">
-            <img src="images/other/Infographic/img001.png" alt="Through my lens" loading="lazy">
-          </div>
-          <div class="card-body">
-            <p class="card-cat">infographic</p>
-            <h3 class="card-title">Through my lens</h3>
-            <p class="card-desc">An illustrated map of a week in photos, sequenced from dawn to night.</p>
-          </div>
-        </a>
-      </article>
-
-      <article class="card reveal" style="transition-delay:160ms">
-        <a href="bmc.html" style="text-decoration:none; color:inherit; display:flex; flex-direction:column; height:100%;">
-          <div class="card-img">
-            <img src="images/other/bmc-cover.png" alt="Boston Children Museum" loading="lazy">
-          </div>
-          <div class="card-body">
-            <p class="card-cat">branding</p>
-            <h3 class="card-title">Boston Children Museum</h3>
-            <p class="card-desc">A refreshed identity system for exhibits, signage, and donor touchpoints.</p>
-          </div>
-        </a>
-      </article>
-
-      <article class="card reveal" style="transition-delay:240ms">
-        <a href="project-04.html" style="text-decoration:none; color:inherit; display:flex; flex-direction:column; height:100%;">
-          <div class="card-img">
-            <img src="images/vietvaluealliance/img001.jpg" alt="Viet Value Alliance" loading="lazy">
-          </div>
-          <div class="card-body">
-            <p class="card-cat">branding · web design</p>
-            <h3 class="card-title">Viet Value Alliance</h3>
-            <p class="card-desc">Brand identity and web design for a Vietnam-based smart home and security startup.</p>
-          </div>
-        </a>
-      </article>
-
-      <article class="card reveal" style="transition-delay:320ms">
-        <a href="mcle.html" style="text-decoration:none; color:inherit; display:flex; flex-direction:column; height:100%;">
-          <div class="card-img">
-            <img src="images/mcle/mcle1.png" alt="MCLE Program Scholarships" loading="lazy">
-          </div>
-          <div class="card-body">
-            <p class="card-cat">visual design</p>
-            <h3 class="card-title">MCLE</h3>
-            <p class="card-desc">A focused visual exercise — clear hierarchy and crisp cues for a continuing-education piece.</p>
-          </div>
-        </a>
-      </article>
     </div>
   </section>
 

--- a/index.html
+++ b/index.html
@@ -435,7 +435,7 @@ html { scroll-behavior: smooth; }
 <!-- Nav -->
 <header class="nav" id="nav">
   <a href="index.html" class="nav-logo">phuong vu</a>
-  <button class="nav-menu-btn" id="navMenuBtn" aria-label="Toggle menu">
+  <button type="button" class="nav-menu-btn" id="navMenuBtn" aria-label="Toggle menu">
     <span></span>
     <span></span>
     <span></span>
@@ -610,7 +610,7 @@ html { scroll-behavior: smooth; }
   </div>
 </footer>
 
-<button id="backToTop" aria-label="Back to top">
+<button type="button" id="backToTop" aria-label="Back to top">
   <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" d="M5 10l7-7m0 0l7 7m-7-7v18"/></svg>
 </button>
 

--- a/infographic.html
+++ b/infographic.html
@@ -162,7 +162,7 @@ html { scroll-behavior: smooth; }
 
 <header class="nav" id="nav">
   <a href="index.html" class="nav-logo">phuong vu</a>
-  <button class="nav-menu-btn" id="navMenuBtn" aria-label="Toggle menu">
+  <button type="button" class="nav-menu-btn" id="navMenuBtn" aria-label="Toggle menu">
     <span></span>
     <span></span>
     <span></span>
@@ -299,12 +299,12 @@ html { scroll-behavior: smooth; }
   </div>
 </footer>
 
-<button id="backToTop" aria-label="Back to top">
+<button type="button" id="backToTop" aria-label="Back to top">
   <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" d="M5 10l7-7m0 0l7 7m-7-7v18"/></svg>
 </button>
 
 <div class="lightbox" id="lightbox">
-  <button class="lightbox-close" aria-label="Close" id="lightboxClose">
+  <button type="button" class="lightbox-close" aria-label="Close" id="lightboxClose">
     <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" d="M6 18L18 6M6 6l12 12"/></svg>
   </button>
   <img src="" alt="Expanded view" id="lightboxImg">

--- a/intervention.html
+++ b/intervention.html
@@ -153,7 +153,7 @@ html { scroll-behavior: smooth; }
 
 <header class="nav" id="nav">
   <a href="index.html" class="nav-logo">phuong vu</a>
-  <button class="nav-menu-btn" id="navMenuBtn" aria-label="Toggle menu">
+  <button type="button" class="nav-menu-btn" id="navMenuBtn" aria-label="Toggle menu">
     <span></span>
     <span></span>
     <span></span>
@@ -262,12 +262,12 @@ html { scroll-behavior: smooth; }
   </div>
 </footer>
 
-<button id="backToTop" aria-label="Back to top">
+<button type="button" id="backToTop" aria-label="Back to top">
   <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" d="M5 10l7-7m0 0l7 7m-7-7v18"/></svg>
 </button>
 
 <div class="lightbox" id="lightbox">
-  <button class="lightbox-close" aria-label="Close" id="lightboxClose">
+  <button type="button" class="lightbox-close" aria-label="Close" id="lightboxClose">
     <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" d="M6 18L18 6M6 6l12 12"/></svg>
   </button>
   <img src="" alt="Expanded view" id="lightboxImg">

--- a/mcle.html
+++ b/mcle.html
@@ -134,7 +134,7 @@ html { scroll-behavior: smooth; }
 
 <header class="nav" id="nav">
   <a href="index.html" class="nav-logo">phuong vu</a>
-  <button class="nav-menu-btn" id="navMenuBtn" aria-label="Toggle menu">
+  <button type="button" class="nav-menu-btn" id="navMenuBtn" aria-label="Toggle menu">
     <span></span>
     <span></span>
     <span></span>
@@ -189,12 +189,12 @@ html { scroll-behavior: smooth; }
   </div>
 </footer>
 
-<button id="backToTop" aria-label="Back to top">
+<button type="button" id="backToTop" aria-label="Back to top">
   <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" d="M5 10l7-7m0 0l7 7m-7-7v18"/></svg>
 </button>
 
 <div class="lightbox" id="lightbox">
-  <button class="lightbox-close" aria-label="Close" id="lightboxClose">
+  <button type="button" class="lightbox-close" aria-label="Close" id="lightboxClose">
     <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" d="M6 18L18 6M6 6l12 12"/></svg>
   </button>
   <img src="" alt="Expanded view" id="lightboxImg">

--- a/project-01.html
+++ b/project-01.html
@@ -225,7 +225,7 @@ html { scroll-behavior: smooth; }
 
 <header class="nav" id="nav">
   <a href="index.html" class="nav-logo">phuong vu</a>
-  <button class="nav-menu-btn" id="navMenuBtn" aria-label="Toggle menu">
+  <button type="button" class="nav-menu-btn" id="navMenuBtn" aria-label="Toggle menu">
     <span></span>
     <span></span>
     <span></span>
@@ -439,7 +439,7 @@ html { scroll-behavior: smooth; }
         <h2 class="cs-h2">Prototype</h2>
       </div>
       <div class="proto-wrap reveal">
-        <iframe src="https://www.figma.com/embed?embed_host=share&url=https%3A%2F%2Fwww.figma.com%2Fproto%2FqbwEwjyWIjEsTXq2nMvcYF%2FSpringboard-Capstone-II%3Fpage-id%3D248%253A43%26node-id%3D338%253A1518%26viewport%3D451%252C247%252C0.05%26scaling%3Dscale-down%26starting-point-node-id%3D428%253A1371%26show-proto-sidebar%3D1" allowfullscreen title="E-bike prototype"></iframe>
+        <iframe src="https://www.figma.com/embed?embed_host=share&url=https%3A%2F%2Fwww.figma.com%2Fproto%2FqbwEwjyWIjEsTXq2nMvcYF%2FSpringboard-Capstone-II%3Fpage-id%3D248%253A43%26node-id%3D338%253A1518%26viewport%3D451%252C247%252C0.05%26scaling%3Dscale-down%26starting-point-node-id%3D428%253A1371%26show-proto-sidebar%3D1" allowfullscreen loading="lazy" title="E-bike prototype"></iframe>
       </div>
     </section>
 
@@ -494,13 +494,13 @@ html { scroll-behavior: smooth; }
   </div>
 </footer>
 
-<button id="backToTop" aria-label="Back to top">
+<button type="button" id="backToTop" aria-label="Back to top">
   <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" d="M5 10l7-7m0 0l7 7m-7-7v18"/></svg>
 </button>
 
 <!-- Lightbox -->
 <div class="lightbox" id="lightbox">
-  <button class="lightbox-close" id="lightboxClose" aria-label="Close">
+  <button type="button" class="lightbox-close" id="lightboxClose" aria-label="Close">
     <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" d="M6 18L18 6M6 6l12 12"/></svg>
   </button>
   <img src="" alt="Expanded view" id="lightboxImg">

--- a/project-02.html
+++ b/project-02.html
@@ -182,7 +182,7 @@ html { scroll-behavior: smooth; }
 
 <header class="nav" id="nav">
   <a href="index.html" class="nav-logo">phuong vu</a>
-  <button class="nav-menu-btn" id="navMenuBtn" aria-label="Toggle menu">
+  <button type="button" class="nav-menu-btn" id="navMenuBtn" aria-label="Toggle menu">
     <span></span>
     <span></span>
     <span></span>
@@ -428,7 +428,7 @@ html { scroll-behavior: smooth; }
         <h2 class="cs-h2">Prototype</h2>
       </div>
       <div class="proto-wrap reveal">
-        <iframe src="https://www.figma.com/embed?embed_host=share&url=https%3A%2F%2Fwww.figma.com%2Fproto%2FRD1QNkJJcE91tqCKCvVP60%2FSpringboard-Capstone-I---Car-App%3Fpage-id%3D202%253A75%26node-id%3D202%253A76%26viewport%3D988%252C667%252C0.13%26scaling%3Dscale-down%26starting-point-node-id%3D327%253A1217%26show-proto-sidebar%3D1" allowfullscreen title="Kura car care prototype"></iframe>
+        <iframe src="https://www.figma.com/embed?embed_host=share&url=https%3A%2F%2Fwww.figma.com%2Fproto%2FRD1QNkJJcE91tqCKCvVP60%2FSpringboard-Capstone-I---Car-App%3Fpage-id%3D202%253A75%26node-id%3D202%253A76%26viewport%3D988%252C667%252C0.13%26scaling%3Dscale-down%26starting-point-node-id%3D327%253A1217%26show-proto-sidebar%3D1" allowfullscreen loading="lazy" title="Kura car care prototype"></iframe>
       </div>
     </section>
 
@@ -481,12 +481,12 @@ html { scroll-behavior: smooth; }
   </div>
 </footer>
 
-<button id="backToTop" aria-label="Back to top">
+<button type="button" id="backToTop" aria-label="Back to top">
   <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" d="M5 10l7-7m0 0l7 7m-7-7v18"/></svg>
 </button>
 
 <div class="lightbox" id="lightbox">
-  <button class="lightbox-close" id="lightboxClose" aria-label="Close">
+  <button type="button" class="lightbox-close" id="lightboxClose" aria-label="Close">
     <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" d="M6 18L18 6M6 6l12 12"/></svg>
   </button>
   <img src="" alt="Expanded view" id="lightboxImg">

--- a/project-03.html
+++ b/project-03.html
@@ -180,7 +180,7 @@ html { scroll-behavior: smooth; }
 
 <header class="nav" id="nav">
   <a href="index.html" class="nav-logo">phuong vu</a>
-  <button class="nav-menu-btn" id="navMenuBtn" aria-label="Toggle menu">
+  <button type="button" class="nav-menu-btn" id="navMenuBtn" aria-label="Toggle menu">
     <span></span>
     <span></span>
     <span></span>
@@ -380,7 +380,7 @@ html { scroll-behavior: smooth; }
         <h2 class="cs-h2">Prototype</h2>
       </div>
       <div class="proto-wrap reveal">
-        <iframe src="https://www.figma.com/embed?embed_host=share&url=https%3A%2F%2Fwww.figma.com%2Fproto%2FAhG7VXPGv6fFdcFPG9gJ3d%2FSpringboard---Design-Sprint%3Fpage-id%3D0%253A1%26node-id%3D2%253A2%26viewport%3D430%252C122%252C0.09%26scaling%3Dscale-down%26starting-point-node-id%3D2%253A2" allowfullscreen title="PostUp prototype"></iframe>
+        <iframe src="https://www.figma.com/embed?embed_host=share&url=https%3A%2F%2Fwww.figma.com%2Fproto%2FAhG7VXPGv6fFdcFPG9gJ3d%2FSpringboard---Design-Sprint%3Fpage-id%3D0%253A1%26node-id%3D2%253A2%26viewport%3D430%252C122%252C0.09%26scaling%3Dscale-down%26starting-point-node-id%3D2%253A2" allowfullscreen loading="lazy" title="PostUp prototype"></iframe>
       </div>
     </section>
 
@@ -433,12 +433,12 @@ html { scroll-behavior: smooth; }
   </div>
 </footer>
 
-<button id="backToTop" aria-label="Back to top">
+<button type="button" id="backToTop" aria-label="Back to top">
   <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" d="M5 10l7-7m0 0l7 7m-7-7v18"/></svg>
 </button>
 
 <div class="lightbox" id="lightbox">
-  <button class="lightbox-close" id="lightboxClose" aria-label="Close">
+  <button type="button" class="lightbox-close" id="lightboxClose" aria-label="Close">
     <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" d="M6 18L18 6M6 6l12 12"/></svg>
   </button>
   <img src="" alt="Expanded view" id="lightboxImg">

--- a/project-04.html
+++ b/project-04.html
@@ -143,7 +143,7 @@ html { scroll-behavior: smooth; }
 
 <header class="nav" id="nav">
   <a href="index.html" class="nav-logo">phuong vu</a>
-  <button class="nav-menu-btn" id="navMenuBtn" aria-label="Toggle menu">
+  <button type="button" class="nav-menu-btn" id="navMenuBtn" aria-label="Toggle menu">
     <span></span>
     <span></span>
     <span></span>
@@ -227,12 +227,12 @@ html { scroll-behavior: smooth; }
   </div>
 </footer>
 
-<button id="backToTop" aria-label="Back to top">
+<button type="button" id="backToTop" aria-label="Back to top">
   <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" d="M5 10l7-7m0 0l7 7m-7-7v18"/></svg>
 </button>
 
 <div class="lightbox" id="lightbox">
-  <button class="lightbox-close" aria-label="Close" id="lightboxClose">
+  <button type="button" class="lightbox-close" aria-label="Close" id="lightboxClose">
     <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" d="M6 18L18 6M6 6l12 12"/></svg>
   </button>
   <img src="" alt="Expanded view" id="lightboxImg">


### PR DESCRIPTION
## Summary
Removed the card-grid "More projects" section from the homepage and replaced it with a single prominent button-style link. This simplifies the homepage layout and directs users to additional projects via a more intentional call-to-action.

## Changes

### Homepage Layout
- **Removed** the entire `.section-cards` block containing 5 project cards (Pawsitively Clean, Through My Lens, Boston Children Museum, Viet Value Alliance, MCLE)
- **Redesigned** `.more-link` from a text link with underline to a full button component:
  - Added padding (`16px 32px`), border-radius, and background color
  - Increased font size from 14px to 16px and weight from 300 to 400
  - Added border and shadow styling using design tokens
  - Enhanced hover state with transform, shadow, and background transitions
  - Increased icon size from 13px to 16px and arrow offset from 3px to 4px
- **Increased** `.more-link-wrap` padding from `48px 0 0` to `72px 0 0` for better visual hierarchy
- **Updated** responsive styles to remove `.cards-grid` mobile breakpoint rule

### Accessibility & Semantics
- Added explicit `type="button"` attribute to all button elements across all pages (nav menu, back-to-top, lightbox close)
- Added `loading="lazy"` attribute to Figma embed iframes for performance

## Implementation Details
The new `.more-link` button uses the design system's surface, border, and shadow tokens for consistency. Hover interactions include a subtle upward transform (`translateY(-2px)`) and enhanced shadow, matching the card hover pattern used elsewhere on the site. The button maintains the existing SVG icon with improved sizing and animation.

https://claude.ai/code/session_011kLih3xQCgHSC3jZF7VS5a